### PR TITLE
Add an error code to the `unkown option` error

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,29 @@ const args = {
 }
 ```
 
+#### Errors
+
+##### ARG_UNKNOWN_OPTION
+
+If an unknown option (not defined in the spec object) is passed, an error with code `ARG_UNKNOWN_OPTION` will be thrown:
+```js
+// cli.js
+try {
+  require('arg')({ '--hi': String });
+} catch (err) {
+  if (err.code === 'ARG_UNKNOWN_OPTION') {
+    console.log(err.message);
+  } else {
+    throw err;
+  }
+}
+```
+```shell
+node cli.js --extraneous true
+Unknown or unexpected option: --extraneous
+
+
+
 # License
 
 Copyright &copy; 2017-2018 by ZEIT, Inc. Released under the [MIT License](LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -175,10 +175,11 @@ try {
   }
 }
 ```
+
 ```shell
 node cli.js --extraneous true
 Unknown or unexpected option: --extraneous
-
+```
 
 
 # License

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ function arg(opts, {argv, permissive = false} = {}) {
 					continue;
 				} else {
 					const err = new Error(`Unknown or unexpected option: ${originalArgName}`);
-					err.code = 'UNKNOWN_OPTION';
+					err.code = 'ARG_UNKNOWN_OPTION';
 					throw err;
 				}
 			}

--- a/index.js
+++ b/index.js
@@ -51,7 +51,9 @@ function arg(opts, {argv, permissive = false} = {}) {
 					result._.push(arg);
 					continue;
 				} else {
-					throw new Error(`Unknown or unexpected option: ${originalArgName}`);
+					const err = new Error(`Unknown or unexpected option: ${originalArgName}`);
+					err.code = 'UNKNOWN_OPTION';
+					throw err;
 				}
 			}
 


### PR DESCRIPTION
Before:

```javascript
let args
try {
  args = arg(...)
} catch (err) {
  if (err.message.startsWith('Unknown or unexpected option:')) {
    // print a nice error
  }
}
```

After:

```javascript
let args
try {
  args = arg(...)
} catch (err) {
  if (err.code === 'UNKNOWN_OPTION') {
    // print a nice error
  }
}
```