### PR TITLE
Bring down arg publish size

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "repository": "zeit/arg",
   "author": "Josh Junon <junon@zeit.co>",
   "license": "MIT",
+  "files": ["index.js"],
   "scripts": {
     "pretest": "xo",
     "test": "WARN_EXIT=1 jest --coverage -w 2"


### PR DESCRIPTION
I was comparing minimist with arg on packagephobia and saw confusing results.

https://packagephobia.now.sh/result?p=minimist
https://packagephobia.now.sh/result?p=arg

Then I realized yarn.lock etc got published to npm because there is no files array.

Here’s the result:

OLD:

npm notice
npm notice 📦  arg@2.0.0
npm notice === Tarball Contents ===
npm notice 444B    package.json
npm notice 251B    .editorconfig
npm notice 2.2kB   index.js
npm notice 1.1kB   LICENSE.md
npm notice 4.0kB   README.md
npm notice 5.9kB   test.js
npm notice 116.7kB yarn.lock
npm notice === Tarball Details ===
npm notice name:          arg
npm notice version:       2.0.0
npm notice filename:      arg-2.0.0.tgz
npm notice package size:  37.8 kB
npm notice unpacked size: 130.6 kB
npm notice shasum:        ab8c1498d34454525f4637486b6716826df9a257
npm notice integrity:     sha512-nKPzpt+PvgYDK[...]nEmPWJdAfHqQA==
npm notice total files:   7
npm notice

NEW:

npm notice
npm notice 📦  arg@2.0.0
npm notice === Tarball Contents ===
npm notice 469B  package.json
npm notice 2.2kB index.js
npm notice 1.1kB LICENSE.md
npm notice 4.0kB README.md
npm notice === Tarball Details ===
npm notice name:          arg
npm notice version:       2.0.0
npm notice filename:      arg-2.0.0.tgz
npm notice package size:  3.6 kB
npm notice unpacked size: 7.8 kB
npm notice shasum:        e9175b5eb18d0322f8156b07f7c5187b29a9967e
npm notice integrity:     sha512-hRJFtZhTsLF8S[...]ELt03n5naJcrw==
npm notice total files:   4
npm notice
arg-2.0.0.tgz