### PR TITLE
Add support for TypeScript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,21 @@
+declare function arg<T extends arg.Spec>(spec: T): arg.Result<T>;
+
+declare namespace arg {
+	export type Handler = (value: string) => any;
+
+	export interface Spec {
+		[key: string]: string | Handler | [Handler];
+	}
+
+	export type Result<T extends Spec> = { _: string[] } & {
+		[K in keyof T]: T[K] extends string
+			? never
+			: T[K] extends Handler
+			? ReturnType<T[K]>
+			: T[K] extends [Handler]
+			? Array<ReturnType<T[K][0]>>
+			: never
+	};
+}
+
+export = arg;

--- a/package.json
+++ b/package.json
@@ -3,11 +3,13 @@
   "version": "2.0.1",
   "description": "Another simple argument parser",
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": "zeit/arg",
   "author": "Josh Junon <junon@zeit.co>",
   "license": "MIT",
   "files": [
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "scripts": {
     "pretest": "xo",


### PR DESCRIPTION
I love the simplicity of this project and want to start adopting it across the projects I maintain (replacing minimist). Providing a TypeScript definition will make adoption a lot easier by adding type safety in any strictly typed projects. Additionally, anyone using VS Code (and other editors with `.d.ts` support) with JavaScript will appreciate the automatic type output. It works by mapping over the "spec" type and producing the types according to the function return type (e.g. `String` is `(x: string) => string` and it'll pick out `string` from the return type).