### PR TITLE
Add `arg.of` for array support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,21 +1,23 @@
 declare function arg<T extends arg.Spec>(spec: T): arg.Result<T>;
 
 declare namespace arg {
-	export type Handler = (value: string) => any;
+	export type Handler<T> = (value: string, argName: string, prev: T) => T;
 
 	export interface Spec {
-		[key: string]: string | Handler | [Handler];
+		[key: string]: string | Handler<any>;
 	}
 
 	export type Result<T extends Spec> = { _: string[] } & {
 		[K in keyof T]: T[K] extends string
 			? never
-			: T[K] extends Handler
+			: T[K] extends Handler<any>
 			? ReturnType<T[K]>
-			: T[K] extends [Handler]
-			? Array<ReturnType<T[K][0]>>
 			: never
 	};
+
+	export const of: <T>(
+		handler: Handler<T>
+	) => (value: string, argName: string, prev: T) => Array<T>;
 }
 
 export = arg;

--- a/index.js
+++ b/index.js
@@ -22,8 +22,8 @@ function arg(opts, {argv, permissive = false} = {}) {
 
 		const type = opts[key];
 
-		if (!type || (typeof type !== 'function' && !(Array.isArray(type) && type.length === 1 && typeof type[0] === 'function'))) {
-			throw new Error(`Type missing or not a function or valid array type: ${key}`);
+		if (typeof type !== 'function') {
+			throw new TypeError(`Type is not a function: ${key}`);
 		}
 
 		handlers[key] = type;
@@ -61,13 +61,9 @@ function arg(opts, {argv, permissive = false} = {}) {
 				}
 			}
 
-			/* eslint-disable operator-linebreak */
-			const [type, isArray] = Array.isArray(handlers[argName])
-				? [handlers[argName][0], true]
-				: [handlers[argName], false];
-			/* eslint-enable operator-linebreak */
-
+			const type = handlers[argName];
 			let value;
+
 			if (type === Boolean) {
 				value = true;
 			} else if (argStr === undefined) {
@@ -82,15 +78,7 @@ function arg(opts, {argv, permissive = false} = {}) {
 				value = type(argStr, argName, result[argName]);
 			}
 
-			if (isArray) {
-				if (result[argName]) {
-					result[argName].push(value);
-				} else {
-					result[argName] = [value];
-				}
-			} else {
-				result[argName] = value;
-			}
+			result[argName] = value;
 		} else {
 			result._.push(arg);
 		}
@@ -98,5 +86,9 @@ function arg(opts, {argv, permissive = false} = {}) {
 
 	return result;
 }
+
+arg.of = fn => (value, argName, prev = []) => {
+	return prev.concat(fn(value, argName, prev[prev.length - 1]));
+};
 
 module.exports = arg;

--- a/test.js
+++ b/test.js
@@ -61,23 +61,23 @@ test('basic custom type parsing', () => {
 
 test('basic string parsing (array)', () => {
 	const argv = ['hey', '--foo', 'hi', 'hello', '--foo', 'hey'];
-	expect(arg({'--foo': [String]}, {argv})).to.deep.equal({_: ['hey', 'hello'], '--foo': ['hi', 'hey']});
+	expect(arg({'--foo': arg.of(String)}, {argv})).to.deep.equal({_: ['hey', 'hello'], '--foo': ['hi', 'hey']});
 });
 
 test('basic number parsing (array)', () => {
 	const argv = ['hey', '--foo', '1234', 'hello', '--foo', '5432'];
-	expect(arg({'--foo': [Number]}, {argv})).to.deep.equal({_: ['hey', 'hello'], '--foo': [1234, 5432]});
+	expect(arg({'--foo': arg.of(Number)}, {argv})).to.deep.equal({_: ['hey', 'hello'], '--foo': [1234, 5432]});
 });
 
 test('basic boolean parsing (array)', () => {
 	const argv = ['hey', '--foo', '1234', 'hello', '--foo', 'hallo'];
-	expect(arg({'--foo': [Boolean]}, {argv})).to.deep.equal({_: ['hey', '1234', 'hello', 'hallo'], '--foo': [true, true]});
+	expect(arg({'--foo': arg.of(Boolean)}, {argv})).to.deep.equal({_: ['hey', '1234', 'hello', 'hallo'], '--foo': [true, true]});
 });
 
 test('basic custom type parsing (array)', () => {
 	const argv = ['hey', '--foo', '1234', 'hello', '--foo', '8911hi'];
 	const customType = (val, name) => `:${name}:${val}:`;
-	expect(arg({'--foo': [customType]}, {argv})).to.deep.equal({_: ['hey', 'hello'], '--foo': [':--foo:1234:', ':--foo:8911hi:']});
+	expect(arg({'--foo': arg.of(customType)}, {argv})).to.deep.equal({_: ['hey', 'hello'], '--foo': [':--foo:1234:', ':--foo:8911hi:']});
 });
 
 test('basic alias parsing', () => {


### PR DESCRIPTION
Thought experiment in https://github.com/zeit/arg/issues/11#issuecomment-445638331.

It doesn't work right now because of how `Boolean` is handled (it's specially flagged). This is both a good example of being unable to write a custom function using `Boolean` and a bad example as it shows it would be tricky to use any special "flag" logic once you wrap it (since you lose the reference).