### PR TITLE
Support combined boolean flags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,17 @@
+version: 2
+jobs:
+    build:
+        docker:
+            - image: circleci/node:10
+        working_directory: ~/repo
+        steps:
+            - checkout
+            - run:
+                name: Installing Dependencies
+                command: yarn install
+            - run:
+                name: Unit Tests
+                command: yarn test
+            - run:
+                name: Coverage
+                command: yarn test-coverage

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+*
+!index.js
+!index.d.ts

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# Arg
+# arg
+
+[![Build Status](https://circleci.com/gh/zeit/arg.svg?&style=shield)](https://circleci.com/gh/zeit/workflows/arg)
+[![codecov](https://codecov.io/gh/zeit/arg/branch/master/graph/badge.svg)](https://codecov.io/gh/zeit/arg)
 
 `arg` is yet another command line option parser.
 

--- a/index.js
+++ b/index.js
@@ -26,6 +26,10 @@ function arg(opts, {argv, permissive = false} = {}) {
 			throw new Error(`Type missing or not a function or valid array type: ${key}`);
 		}
 
+		if (key.substring(0, 2) !== '--' && key.length !== 2) {
+			throw new Error(`Single-hyphen properties must be one character: ${key}`);
+		}
+
 		handlers[key] = type;
 	}
 

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function arg(opts, {argv, permissive = false} = {}) {
 		}
 
 		if (key.length === 1) {
-			throw new Error(`Argument key must have a name; singular "-" keys are not allowed: ${key}`);
+			throw new TypeError(`Argument key must have a name; singular "-" keys are not allowed: ${key}`);
 		}
 
 		if (typeof opts[key] === 'string') {
@@ -27,11 +27,11 @@ function arg(opts, {argv, permissive = false} = {}) {
 		const type = opts[key];
 
 		if (!type || (typeof type !== 'function' && !(Array.isArray(type) && type.length === 1 && typeof type[0] === 'function'))) {
-			throw new Error(`Type missing or not a function or valid array type: ${key}`);
+			throw new TypeError(`Type missing or not a function or valid array type: ${key}`);
 		}
 
 		if (key[1] !== '-' && key.length > 2) {
-			throw new Error(`Short argument keys (with a single hyphen) must have only one character: ${key}`);
+			throw new TypeError(`Short argument keys (with a single hyphen) must have only one character: ${key}`);
 		}
 
 		handlers[key] = type;
@@ -66,7 +66,9 @@ function arg(opts, {argv, permissive = false} = {}) {
 						if (`-${char}` in handlers) {
 							argv.push(`-${char}`);
 						} else {
-							throw new Error(`Unkown or unexpected option: -${char}`);
+							const err = new Error(`Unknown or unexpected option: -${char}`);
+							err.code = 'ARG_UNKNOWN_OPTION';
+							throw err;
 						}
 					}
 
@@ -75,7 +77,9 @@ function arg(opts, {argv, permissive = false} = {}) {
 					result._.push(arg);
 					continue;
 				} else {
-					throw new Error(`Unknown or unexpected option: ${originalArgName}`);
+					const err = new Error(`Unknown or unexpected option: ${originalArgName}`);
+					err.code = 'ARG_UNKNOWN_OPTION';
+					throw err;
 				}
 			}
 

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ function arg(opts, {argv, permissive = false} = {}) {
 		handlers[key] = type;
 	}
 
-	for (let i = 0, len = argv.length; i < len; i++) {
+	for (let i = 0; i < argv.length; i++) {
 		const arg = argv[i];
 
 		if (arg.length < 2) {
@@ -59,29 +59,23 @@ function arg(opts, {argv, permissive = false} = {}) {
 			}
 
 			if (!(argName in handlers)) {
-				// Handle repeating boolean flags
 				const shortArg = argName.substring(0, 2);
-				const rest = argName.substring(2);
-				if (shortArg in handlers &&
-					Array.isArray(handlers[shortArg]) &&
-					rest.length > 0 &&
-					rest === argName.substring(1, 2).repeat(rest.length)
-				) {
-					argName = shortArg;
-
-					if (!result[argName]) {
-						result[argName] = [];
+				const flags = argName.substring(1);
+				if (shortArg in handlers && flags.length > 1) {
+					for (const char of flags) {
+						if (`-${char}` in handlers) {
+							argv.push(`-${char}`);
+						} else {
+							throw new Error(`Unkown or unexpected option: -${char}`);
+						}
 					}
 
-					result[argName].push(...Array(rest.length + 1).fill(true));
 					continue;
 				} else if (permissive) {
 					result._.push(arg);
 					continue;
 				} else {
-					const err = new Error(`Unknown or unexpected option: ${originalArgName}`);
-					err.code = 'ARG_UNKNOWN_OPTION';
-					throw err;
+					throw new Error(`Unknown or unexpected option: ${originalArgName}`);
 				}
 			}
 

--- a/index.js
+++ b/index.js
@@ -65,8 +65,8 @@ function arg(opts, {argv, permissive = false} = {}) {
 				) {
 					argName = shortArg;
 					result[argName] = result[argName] ?
-						result[argName] += rest.length + 1 :
-						result[argName] = rest.length + 1;
+						result[argName] + rest.length + 1 :
+						rest.length + 1;
 					continue;
 				} else if (permissive) {
 					result._.push(arg);
@@ -86,8 +86,8 @@ function arg(opts, {argv, permissive = false} = {}) {
 			if (type === Boolean) {
 				if (isArray) {
 					result[argName] = result[argName] ?
-						result[argName] += 1 :
-						result[argName] = 1;
+						result[argName] + 1 :
+						1;
 					continue;
 				} else {
 					value = true;

--- a/package.json
+++ b/package.json
@@ -6,21 +6,26 @@
   "repository": "zeit/arg",
   "author": "Josh Junon <junon@zeit.co>",
   "license": "MIT",
-  "files": [
-    "index.js"
-  ],
   "scripts": {
     "pretest": "xo",
-    "test": "WARN_EXIT=1 jest --coverage -w 2"
+    "codecov": "codecov",
+    "test": "jest",
+    "test-coverage": "WARN_EXIT=1 jest --coverage -w 2 && codecov"
   },
   "xo": {
     "rules": {
       "complexity": 0
     }
   },
+  "jest": {
+    "coverageDirectory": "./coverage/",
+    "collectCoverage": true
+  },
   "devDependencies": {
     "chai": "^4.1.1",
+    "codecov": "^3.1.0",
     "jest": "^20.0.4",
     "xo": "^0.18.2"
-  }
+  },
+  "dependencies": {}
 }

--- a/test.js
+++ b/test.js
@@ -71,7 +71,7 @@ test('basic number parsing (array)', () => {
 
 test('basic boolean parsing (array)', () => {
 	const argv = ['hey', '--foo', '1234', 'hello', '--foo', 'hallo'];
-	expect(arg({'--foo': [Boolean]}, {argv})).to.deep.equal({_: ['hey', '1234', 'hello', 'hallo'], '--foo': 2});
+	expect(arg({'--foo': [Boolean]}, {argv})).to.deep.equal({_: ['hey', '1234', 'hello', 'hallo'], '--foo': [true, true]});
 });
 
 test('basic custom type parsing (array)', () => {
@@ -189,6 +189,11 @@ test('ensure that all argument properties start with a hyphen', () => {
 	).to.throw(TypeError, 'Argument key must start with \'-\' but found: \'bar\'');
 });
 
+test('single hyphen cannot be key', () => {
+	const argv = ['--foo', '-'];
+	expect(() => (arg({'--foo': Boolean, '-': Boolean}, {argv})).to.throw('Argument key must have a name; singular "-" keys are not allowed: -'));
+});
+
 test('ensure single-hyphen properties are one character', () => {
 	const argv = ['-vv', '--foo'];
 	expect(() => (arg({'-vv': Boolean}, {argv, permissive: true})).to.throw('Single-hyphen properties must be one character: -vv'));
@@ -196,5 +201,5 @@ test('ensure single-hyphen properties are one character', () => {
 
 test('correctly parse repeating boolean flags', () => {
 	const argv = ['-vvvv', '-v', '--foo', '--foo'];
-	expect(arg({'-v': [Boolean], '--foo': Boolean}, {argv, permissive: true})).to.deep.equal({_: [], '-v': 5, '--foo': true});
+	expect(arg({'-v': [Boolean], '--foo': Boolean}, {argv, permissive: true})).to.deep.equal({_: [], '-v': [true, true, true, true, true], '--foo': true});
 });

--- a/test.js
+++ b/test.js
@@ -71,7 +71,7 @@ test('basic number parsing (array)', () => {
 
 test('basic boolean parsing (array)', () => {
 	const argv = ['hey', '--foo', '1234', 'hello', '--foo', 'hallo'];
-	expect(arg({'--foo': [Boolean]}, {argv})).to.deep.equal({_: ['hey', '1234', 'hello', 'hallo'], '--foo': [true, true]});
+	expect(arg({'--foo': [Boolean]}, {argv})).to.deep.equal({_: ['hey', '1234', 'hello', 'hallo'], '--foo': 2});
 });
 
 test('basic custom type parsing (array)', () => {
@@ -187,4 +187,14 @@ test('ensure that all argument properties start with a hyphen', () => {
 			'--baz': Boolean
 		})
 	).to.throw(TypeError, 'Argument key must start with \'-\' but found: \'bar\'');
+});
+
+test('ensure single-hyphen properties are one character', () => {
+	const argv = ['-vv', '--foo'];
+	expect(() => (arg({'-vv': Boolean}, {argv, permissive: true})).to.throw('Single-hyphen properties must be one character: -vv'));
+});
+
+test('correctly parse repeating boolean flags', () => {
+	const argv = ['-vvvv', '-v', '--foo', '--foo'];
+	expect(arg({'-v': [Boolean], '--foo': Boolean}, {argv, permissive: true})).to.deep.equal({_: [], '-v': 5, '--foo': true});
 });

--- a/test.js
+++ b/test.js
@@ -203,3 +203,13 @@ test('correctly parse repeating boolean flags', () => {
 	const argv = ['-vvvv', '-v', '--foo', '--foo'];
 	expect(arg({'-v': [Boolean], '--foo': Boolean}, {argv, permissive: true})).to.deep.equal({_: [], '-v': [true, true, true, true, true], '--foo': true});
 });
+
+test('expand combined boolean flags', () => {
+	const argv = ['-abc'];
+	expect(arg({'-a': Boolean, '-b': Boolean, '-c': Boolean}, {argv})).to.deep.equal({_: [], '-a': true, '-b': true, '-c': true});
+});
+
+test('combined boolean flags with boolean arrays', () => {
+	const argv = ['-abcddd', '-d'];
+	expect(arg({'-a': Boolean, '-b': Boolean, '-c': Boolean, '-d': [Boolean]}, {argv})).to.deep.equal({_: [], '-a': true, '-b': true, '-c': true, '-d': [true, true, true, true]});
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -50,6 +50,16 @@ ajv@^5.1.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
 
+ajv@^6.5.5:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.6.1.tgz#6360f5ed0d80f232cc2b294c362d5dc2e538dd61"
+  integrity sha512-ZoJjft5B+EJBjUyu9C9Hc0OZyPZSSlOF+plzouTrg6UlA8f+e/n8NIgBFG/9tppJtpPWfthHakK7juJdNDODww==
+  dependencies:
+    fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/align-text/-/align-text-0.1.4.tgz#0cd90a561093f35d0a99256c22b7069433fad117"
@@ -112,6 +122,11 @@ argparse@^1.0.7:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
   dependencies:
     sprintf-js "~1.0.2"
+
+argv@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/argv/-/argv-0.0.2.tgz#ecbd16f8949b157183711b1bda334f37840185ab"
+  integrity sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=
 
 arr-diff@^2.0.0:
   version "2.0.0"
@@ -186,6 +201,11 @@ aws-sign2@~0.7.0:
 aws4@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
+
+aws4@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
+  integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
 babel-code-frame@^6.16.0, babel-code-frame@^6.26.0:
   version "6.26.0"
@@ -533,6 +553,17 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
+codecov@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.1.0.tgz#340bd968d361f256976b5af782dd8ba9f82bc849"
+  integrity sha512-aWQc/rtHbcWEQLka6WmBAOpV58J2TwyXqlpAQGhQaSiEUoigTTUk6lLd2vB3kXkhnDyzyH74RXfmV4dq2txmdA==
+  dependencies:
+    argv "^0.0.2"
+    ignore-walk "^3.0.1"
+    js-yaml "^3.12.0"
+    request "^2.87.0"
+    urlgrey "^0.4.4"
+
 color-convert@^1.9.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.1.tgz#c1261107aeb2f294ebffec9ed9ecad529a6097ed"
@@ -546,6 +577,13 @@ color-name@^1.1.1:
 combined-stream@1.0.6, combined-stream@~1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
+  dependencies:
+    delayed-stream "~1.0.0"
+
+combined-stream@^1.0.6, combined-stream@~1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.7.tgz#2d1d24317afb8abe95d6d2c0b07b57813539d828"
+  integrity sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==
   dependencies:
     delayed-stream "~1.0.0"
 
@@ -1076,6 +1114,11 @@ extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
+extend@~3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
+
 extglob@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
@@ -1093,6 +1136,11 @@ extsprintf@^1.2.0:
 fast-deep-equal@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
+
+fast-deep-equal@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+  integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
 
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
@@ -1191,6 +1239,15 @@ form-data@~2.3.1:
   dependencies:
     asynckit "^0.4.0"
     combined-stream "1.0.6"
+    mime-types "^2.1.12"
+
+form-data@~2.3.2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
+  integrity sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
 fs.realpath@^1.0.0:
@@ -1348,6 +1405,14 @@ har-validator@~5.0.3:
     ajv "^5.1.0"
     har-schema "^2.0.0"
 
+har-validator@~5.1.0:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.3.tgz#1ef89ebd3e4996557675eed9893110dc350fa080"
+  integrity sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==
+  dependencies:
+    ajv "^6.5.5"
+    har-schema "^2.0.0"
+
 has-ansi@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
@@ -1413,6 +1478,13 @@ http-signature@~1.2.0:
 iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
+
+ignore-walk@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.1.tgz#a83e62e7d272ac0e3b551aaa82831a19b69f82f8"
+  integrity sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==
+  dependencies:
+    minimatch "^3.0.4"
 
 ignore@^3.2.0, ignore@^3.2.6:
   version "3.3.7"
@@ -1975,6 +2047,14 @@ js-types@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/js-types/-/js-types-1.0.0.tgz#d242e6494ed572ad3c92809fc8bed7f7687cbf03"
 
+js-yaml@^3.12.0:
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
+  integrity sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 js-yaml@^3.5.1, js-yaml@^3.7.0:
   version "3.11.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.11.0.tgz#597c1a8bd57152f26d622ce4117851a51f5ebaef"
@@ -2021,6 +2101,11 @@ json-parse-better-errors@^1.0.1:
 json-schema-traverse@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
+
+json-schema-traverse@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
+  integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
 json-schema@0.2.3:
   version "0.2.3"
@@ -2246,11 +2331,23 @@ mime-db@~1.33.0:
   version "1.33.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
 
+mime-db@~1.37.0:
+  version "1.37.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.37.0.tgz#0b6a0ce6fdbe9576e25f1f2d2fde8830dc0ad0d8"
+  integrity sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==
+
 mime-types@^2.1.12, mime-types@~2.1.17:
   version "2.1.18"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
   dependencies:
     mime-db "~1.33.0"
+
+mime-types@~2.1.19:
+  version "2.1.21"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.21.tgz#28995aa1ecb770742fe6ae7e58f9181c744b3f96"
+  integrity sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==
+  dependencies:
+    mime-db "~1.37.0"
 
 minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
@@ -2342,6 +2439,11 @@ number-is-nan@^1.0.0:
 oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
+
+oauth-sign@~0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
+  integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
 obj-props@^1.0.0:
   version "1.1.0"
@@ -2597,13 +2699,28 @@ pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
+psl@^1.1.24:
+  version "1.1.29"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.29.tgz#60f580d360170bb722a797cc704411e6da850c67"
+  integrity sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==
+
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
+punycode@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
 qs@~6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
+
+qs@~6.5.2:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
+  integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
 randomatic@^1.1.3:
   version "1.1.7"
@@ -2752,6 +2869,32 @@ request@^2.79.0:
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
 
+request@^2.87.0:
+  version "2.88.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
+  integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.8.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.6"
+    extend "~3.0.2"
+    forever-agent "~0.6.1"
+    form-data "~2.3.2"
+    har-validator "~5.1.0"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.19"
+    oauth-sign "~0.9.0"
+    performance-now "^2.1.0"
+    qs "~6.5.2"
+    safe-buffer "^5.1.2"
+    tough-cookie "~2.4.3"
+    tunnel-agent "^0.6.0"
+    uuid "^3.3.2"
+
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -2823,6 +2966,11 @@ rx-lite@^3.1.2:
 safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
+
+safe-buffer@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
 sane@~1.6.0:
   version "1.6.0"
@@ -3114,6 +3262,14 @@ tough-cookie@^2.3.2, tough-cookie@~2.3.3:
   dependencies:
     punycode "^1.4.1"
 
+tough-cookie@~2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
+  integrity sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==
+  dependencies:
+    psl "^1.1.24"
+    punycode "^1.4.1"
+
 tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
@@ -3187,11 +3343,23 @@ update-notifier@^2.1.0:
     semver-diff "^2.0.0"
     xdg-basedir "^3.0.0"
 
+uri-js@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
+  integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
+  dependencies:
+    punycode "^2.1.0"
+
 url-parse-lax@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-1.0.0.tgz#7af8f303645e9bd79a272e7a14ac68bc0609da73"
   dependencies:
     prepend-http "^1.0.1"
+
+urlgrey@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/urlgrey/-/urlgrey-0.4.4.tgz#892fe95960805e85519f1cd4389f2cb4cbb7652f"
+  integrity sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=
 
 user-home@^2.0.0:
   version "2.0.0"
@@ -3206,6 +3374,11 @@ util-deprecate@~1.0.1:
 uuid@^3.1.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
+
+uuid@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
 validate-npm-package-license@^3.0.1:
   version "3.0.3"


### PR DESCRIPTION
This pull request builds upon #14 and should be a major bump if merged.

I guess 14 can be closed? Not sure of the best way to build upon an open pull request and also introduce a new feature.

- Support combining multiple boolean flags into a single flag. Now `-abcd` will correctly be interpreted as `-a -b -c -d`.
- Works in combination with boolean array arguments, such that `-abcc` will be result in `[true, true]` if `-c` was declared as a `[Boolean]`.

Also generally improves the logic so that it will be easier to add support for whatever comes out of #11.