### PR TITLE
Enforce Single Character Short Arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,10 @@ function arg(opts, {argv, permissive = false} = {}) {
 			throw new TypeError(`Argument key must start with '-' but found: '${key}'`);
 		}
 
+		if (key.length === 1) {
+			throw new TypeError(`Argument key must have a name; singular '-' keys are not allowed: ${key}`);
+		}
+
 		if (typeof opts[key] === 'string') {
 			aliases[key] = opts[key];
 			continue;
@@ -24,6 +28,10 @@ function arg(opts, {argv, permissive = false} = {}) {
 
 		if (!type || (typeof type !== 'function' && !(Array.isArray(type) && type.length === 1 && typeof type[0] === 'function'))) {
 			throw new Error(`Type missing or not a function or valid array type: ${key}`);
+		}
+
+		if (key[1] !== '-' && key.length > 2) {
+			throw new TypeError(`Short argument keys (with a single hyphen) must have only one character: ${key}`);
 		}
 
 		handlers[key] = type;

--- a/test.js
+++ b/test.js
@@ -137,6 +137,16 @@ test('error: non-function type', () => {
 	expect(() => arg({'--foo': undefined}, {argv})).to.throw('Type missing or not a function or valid array type: --foo');
 });
 
+test('error: no singular - keys allowed', () => {
+	const argv = ['--foo', '--bar', '1234'];
+	expect(() => arg({'-': Boolean, '--bar': Number}, {argv})).to.throw('Argument key must have a name; singular \'-\' keys are not allowed: -');
+});
+
+test('error: no multi character short arguments', () => {
+	const argv = ['--foo', '--bar', '1234'];
+	expect(() => arg({'-abc': Boolean, '--bar': Number}, {argv})).to.throw('Short argument keys (with a single hyphen) must have only one character: -abc');
+});
+
 test('permissive mode allows unknown args', () => {
 	const argv = ['foo', '--real', 'nice', '--unreal', 'stillnice', '-a', '1', '-b', '2', 'goodbye'];
 	const result = arg(


### PR DESCRIPTION
- Arguments that start with a single hyphen (aka short arguments)
and are longer than one character (like `-xyz`) now throw an error.
- Arguments that are a just a single hyphen (`-`) will now throw an error.
- Added tests for both of these cases.

Sorry it took so long for this, just got back from travel.