### PR TITLE
Add condensed shortargs / arg.COUNT

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,37 @@ Type functions are passed three arguments:
 
 This means the built-in `String`, `Number`, and `Boolean` type constructors "just work" as type functions.
 
+Note that `Boolean` and `[Boolean]` have special treatment - an option argument is _not_ consumed or passed, but instead `true` is
+returned. These options are called "flags".
+
+For custom handlers that wish to behave as flags, you may pass the function through `arg.flag()`:
+
+```javascript
+const arg = require('arg');
+
+const argv = ['--foo', 'bar', '-ff', 'baz', '--foo', '--foo', 'qux', '-fff', 'qix'];
+
+function myHandler(value, argName, previousValue) {
+	/* `value` is always `true` */
+	return 'na ' + (previousValue || 'batman!');
+}
+
+const args = arg({
+	'--foo': arg.flag(myHandler),
+	'-f': '--foo'
+}, {
+	argv
+});
+
+console.log(args);
+/*
+{
+	_: ['foo', 'baz', 'qux', 'qix'],
+	'--foo': 'na na na na na na na na batman!'
+}
+*/
+```
+
 As well, `arg` supplies a helper argument handler called `arg.COUNT`, which equivalent to a `[Boolean]` argument's `.length`
 property - effectively counting the number of times the boolean flag, denoted by the key, is passed on the command line..
 For example, this is how you could implement `ssh`'s multiple levels of verbosity (`-vvvv` being the most verbose).

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ const args = arg(spec, options = {permissive: false, argv: process.argv.slice(2)
 For example:
 
 ```console
-$ node ./hello.js --port=1234 -n 'My name' foo bar --tag qux --tag=qix -- --foobar
+$ node ./hello.js --verbose -vvv --port=1234 -n 'My name' foo bar --tag qux --tag=qix -- --foobar
 ```
 
 ```javascript
@@ -52,12 +52,13 @@ const args = arg({
 	// Types
 	'--help':    Boolean,
 	'--version': Boolean,
+	'--verbose': arg.COUNT,   // Counts the number of times --verbose is passed
 	'--port':    Number,      // --port <number> or --port=<number>
 	'--name':    String,      // --name <string> or --name=<string>
 	'--tag':     [String],    // --tag <string> or --tag=<string>
 
 	// Aliases
-	'-v':        '--version',
+	'-v':        '--verbose',
 	'-n':        '--name',    // -n <string>; result is stored in --name
 	'--label':   '--name'     // --label <string> or --label=<string>;
 	                          //     result is stored in --name
@@ -68,6 +69,7 @@ console.log(args);
 {
 	_: ["foo", "bar", "--foobar"],
 	'--port': 1234,
+	'--verbose': 4,
 	'--name': "My name",
 	'--tag': ["qux", "qix"]
 }
@@ -93,6 +95,10 @@ Type functions are passed three arguments:
 3. The previous value for the destination (useful for reduce-like operatons or for supporting `-v` multiple times, etc.)
 
 This means the built-in `String`, `Number`, and `Boolean` type constructors "just work" as type functions.
+
+As well, `arg` supplies a helper argument handler called `arg.COUNT`, which equivalent to a `[Boolean]` argument's `.length`
+property - effectively counting the number of times the boolean flag, denoted by the key, is passed on the command line..
+For example, this is how you could implement `ssh`'s multiple levels of verbosity (`-vvvv` being the most verbose).
 
 ### Options
 
@@ -160,6 +166,9 @@ const args = {
 
 #### Errors
 
+Some errors that `arg` throws provide a `.code` property in order to aid in recovering from user error, or to
+differentiate between user error and developer error (bug).
+
 ##### ARG_UNKNOWN_OPTION
 
 If an unknown option (not defined in the spec object) is passed, an error with code `ARG_UNKNOWN_OPTION` will be thrown:
@@ -180,7 +189,6 @@ try {
 node cli.js --extraneous true
 Unknown or unexpected option: --extraneous
 ```
-
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,28 @@ As well, `arg` supplies a helper argument handler called `arg.COUNT`, which equi
 property - effectively counting the number of times the boolean flag, denoted by the key, is passed on the command line..
 For example, this is how you could implement `ssh`'s multiple levels of verbosity (`-vvvv` being the most verbose).
 
+```javascript
+const arg = require('arg');
+
+const argv = ['-AAAA', '-BBBB'];
+
+const args = arg({
+	'-A': arg.COUNT,
+	'-B': [Boolean]
+}, {
+	argv
+});
+
+console.log(args);
+/*
+{
+	_: [],
+	'-A': 4,
+	'-B': [true, true, true, true]
+}
+*/
+```
+
 ### Options
 
 If a second parameter is specified and is an object, it specifies parsing options to modify the behavior of `arg()`.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   },
   "xo": {
     "rules": {
-      "complexity": 0
+      "complexity": 0,
+      "max-depth": 0
     }
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #11. Supersedes #16, #17, and #18 - this needed a bit more complete solution.

This PR adds:

- support for condensed shortargs (e.g. `-vvvs hello`)
- support for arbitrary flag handles via the use of `arg.flag(() => {})`, which attaches a symbol to the handler
- `arg.COUNT`, a flag handler that accumulates the number of times a flag has been passed

These changes are a result of the excellent discussion on #11 and #18.

Everything here is backwards-compatible.