### PR TITLE
Add `flag` and `COUNT` to TypeScript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,13 @@
+declare const flagSymbol: unique symbol;
+
 declare function arg<T extends arg.Spec>(spec: T, options?: {argv?: string[], permissive?: boolean}): arg.Result<T>;
 
 declare namespace arg {
-	export type Handler = (value: string) => any;
+	export function flag<T>(fn: T): T & { [flagSymbol]: true };
+
+	export const COUNT: Handler<number> & { [flagSymbol]: true };
+
+	export type Handler <T = any> = (value: string, name: string, previousValue?: T) => T;
 
 	export interface Spec {
 		[key: string]: string | Handler | [Handler];


### PR DESCRIPTION
Updates type definition with https://github.com/zeit/arg/pull/27 support. Type definition is backward compatible. Technically the `flagSymbol` is not necessary for the types to still be correct, but figured it didn't hurt to add for the little pop-over information in editors like VSCode.