### PR TITLE
Make all argument results optional in type def

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ declare namespace arg {
 	}
 
 	export type Result<T extends Spec> = { _: string[] } & {
-		[K in keyof T]: T[K] extends string
+		[K in keyof T]?: T[K] extends string
 			? never
 			: T[K] extends Handler
 			? ReturnType<T[K]>


### PR DESCRIPTION
I think I overlooked this in my first PR - of course all flags are possibly missing to start with, therefore all the flags should be marked as optional in TypeScript.