### PR TITLE
Add support for `stopEarly` when parsing args

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -26,7 +26,7 @@ declare namespace arg {
 	export interface Options {
 		argv?: string[];
 		permissive?: boolean;
-		stopEarly?: boolean;
+		stopAtPositional?: boolean;
 	}
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 declare const flagSymbol: unique symbol;
 
-declare function arg<T extends arg.Spec>(spec: T, options?: {argv?: string[], permissive?: boolean}): arg.Result<T>;
+declare function arg<T extends arg.Spec>(spec: T, options?: arg.Options): arg.Result<T>;
 
 declare namespace arg {
 	export function flag<T>(fn: T): T & { [flagSymbol]: true };
@@ -22,6 +22,12 @@ declare namespace arg {
 			? Array<ReturnType<T[K][0]>>
 			: never
 	};
+
+	export interface Options {
+		argv?: string[];
+		permissive?: boolean;
+		stopEarly?: boolean;
+	}
 }
 
 export = arg;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const flagSymbol = Symbol('arg flag');
 
-function arg(opts, {argv, permissive = false, stopEarly = false} = {}) {
+function arg(opts, {argv, permissive = false, stopAtPositional = false} = {}) {
 	if (!opts) {
 		throw new Error('Argument specification object is required');
 	}
@@ -42,7 +42,7 @@ function arg(opts, {argv, permissive = false, stopEarly = false} = {}) {
 	for (let i = 0, len = argv.length; i < len; i++) {
 		const wholeArg = argv[i];
 
-		if (stopEarly && result._.length > 0) {
+		if (stopAtPositional && result._.length > 0) {
 			result._ = result._.concat(argv.slice(i));
 			break;
 		}

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const flagSymbol = Symbol('arg flag');
 
-function arg(opts, {argv, permissive = false} = {}) {
+function arg(opts, {argv, permissive = false, stopEarly = false} = {}) {
 	if (!opts) {
 		throw new Error('Argument specification object is required');
 	}
@@ -42,9 +42,9 @@ function arg(opts, {argv, permissive = false} = {}) {
 	for (let i = 0, len = argv.length; i < len; i++) {
 		const wholeArg = argv[i];
 
-		if (wholeArg.length < 2) {
-			result._.push(wholeArg);
-			continue;
+		if (stopEarly && result._.length > 0) {
+			result._ = result._.concat(argv.slice(i));
+			break;
 		}
 
 		if (wholeArg === '--') {
@@ -52,7 +52,7 @@ function arg(opts, {argv, permissive = false} = {}) {
 			break;
 		}
 
-		if (wholeArg[0] === '-') {
+		if (wholeArg.length > 1 && wholeArg[0] === '-') {
 			/* eslint-disable operator-linebreak */
 			const separatedArguments = (wholeArg[1] === '-' || wholeArg.length === 2)
 				? [wholeArg]

--- a/test.js
+++ b/test.js
@@ -309,7 +309,7 @@ test('should stop parsing early with positional argument', () => {
 		'-d': Boolean
 	}, {
 		argv,
-		stopEarly: true
+		stopAtPositional: true
 	});
 
 	expect(result).to.deep.equal({
@@ -325,7 +325,7 @@ test('should stop parsing early with permissive', () => {
 		'-d': arg.COUNT
 	}, {
 		argv,
-		stopEarly: true,
+		stopAtPositional: true,
 		permissive: true
 	});
 

--- a/test.js
+++ b/test.js
@@ -301,3 +301,36 @@ test('should error if a non-flag shortarg comes before a shortarg flag in a cond
 		argv
 	})).to.throw(TypeError, 'Option requires argument (but was followed by another short argument): -s');
 });
+
+test('should stop parsing early with positional argument', () => {
+	const argv = ['-d', 'script', '--foo', 'bar'];
+
+	const result = arg({
+		'-d': Boolean
+	}, {
+		argv,
+		stopEarly: true
+	});
+
+	expect(result).to.deep.equal({
+		_: ['script', '--foo', 'bar'],
+		'-d': true
+	});
+});
+
+test('should stop parsing early with permissive', () => {
+	const argv = ['-dvd', '--foo', 'bar'];
+
+	const result = arg({
+		'-d': arg.COUNT
+	}, {
+		argv,
+		stopEarly: true,
+		permissive: true
+	});
+
+	expect(result).to.deep.equal({
+		_: ['-v', '--foo', 'bar'],
+		'-d': 2
+	});
+});


### PR DESCRIPTION
Closes https://github.com/zeit/arg/issues/31. I wasn't sure on the permissive + combined short-flag use-case though. Should it finish parsing the short flag or should it stop on the first invalid short flag? Or should "permissive" not stop early at all, even though `stopEarly` stops on the first positional?