### PR TITLE
Support parsing `--` into a separate result key

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,7 @@ declare function arg<T extends arg.Spec>(spec: T, options?: {argv?: string[], pe
 
 declare namespace arg {
 	export function flag<T>(fn: T): T & { [flagSymbol]: true };
+	export function of<T>(fn: Handler<T>): Handler<T[]>;
 
 	export const COUNT: Handler<number> & { [flagSymbol]: true };
 

--- a/index.js
+++ b/index.js
@@ -26,17 +26,25 @@ function arg(opts, {argv, permissive = false} = {}) {
 			continue;
 		}
 
-		const type = opts[key];
+		let type = opts[key];
+		let isFlag = false;
 
-		if (!type || (typeof type !== 'function' && !(Array.isArray(type) && type.length === 1 && typeof type[0] === 'function'))) {
-			throw new Error(`Type missing or not a function or valid array type: ${key}`);
+		if (Array.isArray(type) && type.length === 1 && typeof type[0] === 'function') {
+			const [fn] = type;
+
+			type = arg.of(fn);
+			isFlag = fn === Boolean || fn[flagSymbol] === true;
+		} else if (typeof type === 'function') {
+			isFlag = type === Boolean || type[flagSymbol] === true;
+		} else {
+			throw new TypeError(`Type missing or not a function or valid array type: ${key}`);
 		}
 
 		if (key[1] !== '-' && key.length > 2) {
 			throw new TypeError(`Short argument keys (with a single hyphen) must have only one character: ${key}`);
 		}
 
-		handlers[key] = type;
+		handlers[key] = [type, isFlag];
 	}
 
 	for (let i = 0, len = argv.length; i < len; i++) {
@@ -48,6 +56,14 @@ function arg(opts, {argv, permissive = false} = {}) {
 		}
 
 		if (wholeArg === '--') {
+			if (handlers['--']) {
+				const [type] = handlers['--'];
+
+				while (++i < argv.length) {
+					result['--'] = type(argv[i], '--', result['--']);
+				}
+			}
+
 			result._ = result._.concat(argv.slice(i + 1));
 			break;
 		}
@@ -79,41 +95,24 @@ function arg(opts, {argv, permissive = false} = {}) {
 					}
 				}
 
-				/* eslint-disable operator-linebreak */
-				const [type, isArray] = Array.isArray(handlers[argName])
-					? [handlers[argName][0], true]
-					: [handlers[argName], false];
-				/* eslint-enable operator-linebreak */
+				const [type, isFlag] = handlers[argName];
 
-				if (!(type === Boolean || type[flagSymbol]) && ((j + 1) < separatedArguments.length)) {
+				if (!isFlag && ((j + 1) < separatedArguments.length)) {
 					throw new TypeError(`Option requires argument (but was followed by another short argument): ${originalArgName}`);
 				}
 
-				let value;
-				if (type === Boolean) {
-					value = true;
-				} else if (type[flagSymbol]) {
-					value = type(true, argName, result[argName]);
+				if (isFlag) {
+					result[argName] = type(true, argName, result[argName]);
 				} else if (argStr === undefined) {
 					if (argv.length < i + 2 || (argv[i + 1].length > 1 && argv[i + 1][0] === '-')) {
 						const extended = originalArgName === argName ? '' : ` (alias for ${argName})`;
 						throw new Error(`Option requires argument: ${originalArgName}${extended}`);
 					}
 
-					value = type(argv[i + 1], argName, result[argName]);
+					result[argName] = type(argv[i + 1], argName, result[argName]);
 					++i;
 				} else {
-					value = type(argStr, argName, result[argName]);
-				}
-
-				if (isArray) {
-					if (result[argName]) {
-						result[argName].push(value);
-					} else {
-						result[argName] = [value];
-					}
-				} else {
-					result[argName] = value;
+					result[argName] = type(argStr, argName, result[argName]);
 				}
 			}
 		} else {
@@ -127,6 +126,11 @@ function arg(opts, {argv, permissive = false} = {}) {
 arg.flag = fn => {
 	fn[flagSymbol] = true;
 	return fn;
+};
+
+arg.of = fn => (value, name, prev = []) => {
+	prev.push(fn(value, name, prev[prev.length - 1]));
+	return prev;
 };
 
 // Utility types

--- a/test.js
+++ b/test.js
@@ -301,3 +301,21 @@ test('should error if a non-flag shortarg comes before a shortarg flag in a cond
 		argv
 	})).to.throw(TypeError, 'Option requires argument (but was followed by another short argument): -s');
 });
+
+test('should parse `--` into result when defined', () => {
+	const argv = ['--kill', '**/*', '--', 'npm', 'start'];
+
+	const result = arg({
+		'--': [String],
+		'--kill': Boolean,
+		'-k': '--kill'
+	}, {
+		argv
+	});
+
+	expect(result).to.deep.equal({
+		_: ['**/*'],
+		'--': ['npm', 'start'],
+		'--kill': true
+	});
+});


### PR DESCRIPTION
Closes https://github.com/zeit/arg/issues/30. I needed to re-use the same logic of `type` and array handling between the `--` function and regular functions so I created the `arg.of` wrapper that'll automatically be used when the arg is of `[Handler]` type.

This feature allows someone to split `--` args apart from `_` by defining `--` in the `opts` object. All changes are backward compatible with existing code and these changes do not affect the type signature since `{ '--': [String] }` "just works" with the current TypeScript definition.