### PR TITLE
Refactor `type` and `isArray` handling internally

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,7 @@ declare function arg<T extends arg.Spec>(spec: T, options?: {argv?: string[], pe
 
 declare namespace arg {
 	export function flag<T>(fn: T): T & { [flagSymbol]: true };
+	export function of<T>(fn: Handler<T>): Handler<T[]>;
 
 	export const COUNT: Handler<number> & { [flagSymbol]: true };
 
@@ -14,9 +15,7 @@ declare namespace arg {
 	}
 
 	export type Result<T extends Spec> = { _: string[] } & {
-		[K in keyof T]?: T[K] extends string
-			? never
-			: T[K] extends Handler
+		[K in keyof T]?: T[K] extends Handler
 			? ReturnType<T[K]>
 			: T[K] extends [Handler]
 			? Array<ReturnType<T[K][0]>>

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,6 @@ declare function arg<T extends arg.Spec>(spec: T, options?: {argv?: string[], pe
 
 declare namespace arg {
 	export function flag<T>(fn: T): T & { [flagSymbol]: true };
-	export function of<T>(fn: Handler<T>): Handler<T[]>;
 
 	export const COUNT: Handler<number> & { [flagSymbol]: true };
 

--- a/index.js
+++ b/index.js
@@ -26,17 +26,25 @@ function arg(opts, {argv, permissive = false} = {}) {
 			continue;
 		}
 
-		const type = opts[key];
+		let type = opts[key];
+		let isFlag = false;
 
-		if (!type || (typeof type !== 'function' && !(Array.isArray(type) && type.length === 1 && typeof type[0] === 'function'))) {
-			throw new Error(`Type missing or not a function or valid array type: ${key}`);
+		if (Array.isArray(type) && type.length === 1 && typeof type[0] === 'function') {
+			const [fn] = type;
+
+			type = arg.of(fn);
+			isFlag = fn === Boolean || fn[flagSymbol] === true;
+		} else if (typeof type === 'function') {
+			isFlag = type === Boolean || type[flagSymbol] === true;
+		} else {
+			throw new TypeError(`Type missing or not a function or valid array type: ${key}`);
 		}
 
 		if (key[1] !== '-' && key.length > 2) {
 			throw new TypeError(`Short argument keys (with a single hyphen) must have only one character: ${key}`);
 		}
 
-		handlers[key] = type;
+		handlers[key] = [type, isFlag];
 	}
 
 	for (let i = 0, len = argv.length; i < len; i++) {
@@ -79,41 +87,24 @@ function arg(opts, {argv, permissive = false} = {}) {
 					}
 				}
 
-				/* eslint-disable operator-linebreak */
-				const [type, isArray] = Array.isArray(handlers[argName])
-					? [handlers[argName][0], true]
-					: [handlers[argName], false];
-				/* eslint-enable operator-linebreak */
+				const [type, isFlag] = handlers[argName];
 
-				if (!(type === Boolean || type[flagSymbol]) && ((j + 1) < separatedArguments.length)) {
+				if (!isFlag && ((j + 1) < separatedArguments.length)) {
 					throw new TypeError(`Option requires argument (but was followed by another short argument): ${originalArgName}`);
 				}
 
-				let value;
-				if (type === Boolean) {
-					value = true;
-				} else if (type[flagSymbol]) {
-					value = type(true, argName, result[argName]);
+				if (isFlag) {
+					result[argName] = type(true, argName, result[argName]);
 				} else if (argStr === undefined) {
 					if (argv.length < i + 2 || (argv[i + 1].length > 1 && argv[i + 1][0] === '-')) {
 						const extended = originalArgName === argName ? '' : ` (alias for ${argName})`;
 						throw new Error(`Option requires argument: ${originalArgName}${extended}`);
 					}
 
-					value = type(argv[i + 1], argName, result[argName]);
+					result[argName] = type(argv[i + 1], argName, result[argName]);
 					++i;
 				} else {
-					value = type(argStr, argName, result[argName]);
-				}
-
-				if (isArray) {
-					if (result[argName]) {
-						result[argName].push(value);
-					} else {
-						result[argName] = [value];
-					}
-				} else {
-					result[argName] = value;
+					result[argName] = type(argStr, argName, result[argName]);
 				}
 			}
 		} else {
@@ -127,6 +118,11 @@ function arg(opts, {argv, permissive = false} = {}) {
 arg.flag = fn => {
 	fn[flagSymbol] = true;
 	return fn;
+};
+
+arg.of = fn => (value, name, prev = []) => {
+	prev.push(fn(value, name, prev[prev.length - 1]));
+	return prev;
 };
 
 // Utility types

--- a/index.js
+++ b/index.js
@@ -31,7 +31,6 @@ function arg(opts, {argv, permissive = false} = {}) {
 
 		if (Array.isArray(type) && type.length === 1 && typeof type[0] === 'function') {
 			const [fn] = type;
-
 			type = arg.of(fn);
 			isFlag = fn === Boolean || fn[flagSymbol] === true;
 		} else if (typeof type === 'function') {

--- a/index.js
+++ b/index.js
@@ -31,7 +31,10 @@ function arg(opts, {argv, permissive = false} = {}) {
 
 		if (Array.isArray(type) && type.length === 1 && typeof type[0] === 'function') {
 			const [fn] = type;
-			type = arg.of(fn);
+			type = (value, name, prev = []) => {
+				prev.push(fn(value, name, prev[prev.length - 1]));
+				return prev;
+			};
 			isFlag = fn === Boolean || fn[flagSymbol] === true;
 		} else if (typeof type === 'function') {
 			isFlag = type === Boolean || type[flagSymbol] === true;
@@ -117,11 +120,6 @@ function arg(opts, {argv, permissive = false} = {}) {
 arg.flag = fn => {
 	fn[flagSymbol] = true;
 	return fn;
-};
-
-arg.of = fn => (value, name, prev = []) => {
-	prev.push(fn(value, name, prev[prev.length - 1]));
-	return prev;
 };
 
 // Utility types


### PR DESCRIPTION
Splitting the internal handler refactor from https://github.com/zeit/arg/pull/33 into new PR since I'm not sure it'll land with the discussion in https://github.com/zeit/arg/issues/30. This change made it easier to re-use `type` in more than one place in the codebase (currently all the logic for array handling is within the "separated args" loop).