### PR TITLE
Add literalDashes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,71 @@ const args = {
 }
 ```
 
-#### Errors
+#### `stopAtPositional`
+
+When `stopAtPositional` is set to `true`, `arg` will halt parsing at the first
+positional argument.
+
+This is useful for when sub-command handling should occur, or when paired with
+`literalDashes`.
+
+For example:
+
+```javascript
+const arg = require('arg');
+
+const argv = ['--foo', 'hello', '--bar'];
+
+const args = arg(
+	{
+		'--foo': Boolean,
+		'--bar': Boolean
+	}, {
+		argv,
+		stopAtPositional: true
+	}
+);
+```
+
+results in:
+
+```javascript
+const args = {
+	_: ['hello', '--bar'],
+	'--foo': true
+};
+```
+
+#### `literalDashes`
+
+When `literalDashes` is set to `true`, `arg` will treat any occurence of
+`--` as a literal positional argument. Option parsing will continue as normal.
+
+If you want to both treat `--` as a positional _and_ stop parsing options,
+specify `stopAtPositional: true` as well.
+
+For example:
+
+```javascript
+const arg = require('arg');
+
+const argv = ['foo', '--', 'bar'];
+
+const args = arg({}, {
+	argv,
+	literalDashes: true
+});
+```
+
+results in:
+
+```javascript
+const args = {
+	_:          ['foo', '--', 'bar']
+};
+```
+
+### Errors
 
 Some errors that `arg` throws provide a `.code` property in order to aid in recovering from user error, or to
 differentiate between user error and developer error (bug).

--- a/index.d.ts
+++ b/index.d.ts
@@ -27,6 +27,7 @@ declare namespace arg {
 		argv?: string[];
 		permissive?: boolean;
 		stopAtPositional?: boolean;
+		literalDashes?: boolean;
 	}
 }
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const flagSymbol = Symbol('arg flag');
 
-function arg(opts, {argv, permissive = false, stopAtPositional = false} = {}) {
+function arg(opts, {argv, permissive = false, stopAtPositional = false, literalDashes = false} = {}) {
 	if (!opts) {
 		throw new Error('Argument specification object is required');
 	}
@@ -52,8 +52,13 @@ function arg(opts, {argv, permissive = false, stopAtPositional = false} = {}) {
 		}
 
 		if (wholeArg === '--') {
-			result._ = result._.concat(argv.slice(i + 1));
-			break;
+			if (literalDashes) {
+				result._.push('--');
+				continue;
+			} else {
+				result._ = result._.concat(argv.slice(i + 1));
+				break;
+			}
 		}
 
 		if (wholeArg.length > 1 && wholeArg[0] === '-') {

--- a/test.js
+++ b/test.js
@@ -342,3 +342,37 @@ test('should stop parsing early with permissive', () => {
 		'-d': 2
 	});
 });
+
+test('literalDashes: true should insert \'--\' as a positional', () => {
+	const argv = ['foo', '--', 'bar', '--test'];
+
+	const result = arg({
+		'--test': Boolean
+	}, {
+		argv,
+		literalDashes: true
+	});
+
+	expect(result).to.deep.equal({
+		_: ['foo', '--', 'bar'],
+		'--test': true
+	});
+});
+
+test('literalDashes + stopAtPositional should work as expected', () => {
+	const argv = ['--foo', '--', 'bar', '--test'];
+
+	const result = arg({
+		'--test': Boolean,
+		'--foo': Boolean
+	}, {
+		argv,
+		literalDashes: true,
+		stopAtPositional: true
+	});
+
+	expect(result).to.deep.equal({
+		_: ['--', 'bar', '--test'],
+		'--foo': true
+	});
+});


### PR DESCRIPTION
Closes #30. Supercedes #33.

This adds the `literalDashes` option as explained in https://github.com/zeit/arg/issues/30#issuecomment-450615316.

I also filled in a few pieces of missing documentation.