### PR TITLE
Fixed typo in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ in which case an empty array is returned).
 const arg = require('arg');
 
 // `argument_array` is an optional parameter
-const args = arg(spec, options = {permissive: false, argv: process.argv.slice(2)}]);
+const args = arg(spec, options = {permissive: false, argv: process.argv.slice(2)});
 ```
 
 For example:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ in which case an empty array is returned).
 ```javascript
 const arg = require('arg');
 
-// `argument_array` is an optional parameter
+// `options` is an optional parameter
 const args = arg(spec, options = {permissive: false, argv: process.argv.slice(2)});
 ```
 


### PR DESCRIPTION
Noticed a small typo in one of the examples in the readme