### PR TITLE
FIX: Parse long args with '=' in value (#47)

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ function arg(opts, {argv = process.argv.slice(2), permissive = false, stopAtPosi
 
 			for (let j = 0; j < separatedArguments.length; j++) {
 				const arg = separatedArguments[j];
-				const [originalArgName, argStr] = arg[1] === '-' ? arg.split(new RegExp('=(.+)'), 2) : [arg, undefined];
+				const [originalArgName, argStr] = arg[1] === '-' ? arg.split(/[=](.*)/, 2) : [arg, undefined];
 
 				let argName = originalArgName;
 				while (argName in aliases) {

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ function arg(opts, {argv = process.argv.slice(2), permissive = false, stopAtPosi
 
 			for (let j = 0; j < separatedArguments.length; j++) {
 				const arg = separatedArguments[j];
-				const [originalArgName, argStr] = arg[1] === '-' ? arg.split('=', 2) : [arg, undefined];
+				const [originalArgName, argStr] = arg[1] === '-' ? arg.split(new RegExp('=(.+)'), 2) : [arg, undefined];
 
 				let argName = originalArgName;
 				while (argName in aliases) {

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ function arg(opts, {argv = process.argv.slice(2), permissive = false, stopAtPosi
 
 			for (let j = 0; j < separatedArguments.length; j++) {
 				const arg = separatedArguments[j];
-				const [originalArgName, argStr] = arg[1] === '-' ? arg.split(/[=](.*)/, 2) : [arg, undefined];
+				const [originalArgName, argStr] = arg[1] === '-' ? arg.split(/=(.*)/, 2) : [arg, undefined];
 
 				let argName = originalArgName;
 				while (argName in aliases) {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "xo": {
     "rules": {
       "complexity": 0,
-      "max-depth": 0
+      "max-depth": 0,
+      "no-div-regex": 0
     }
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -43,6 +43,11 @@ test('basic string parsing (equals long-arg)', () => {
 	expect(arg({'--foo': String}, {argv})).to.deep.equal({_: ['hey', 'hello'], '--foo': 'hi'});
 });
 
+test('basic string parsing (equals long-arg-with-equals)', () => {
+	const argv = ['hey', '--foo=hi.hello?q=p', 'hello'];
+	expect(arg({'--foo': String}, {argv})).to.deep.equal({_: ['hey', 'hello'], '--foo': 'hi.hello?q=p'});
+});
+
 test('basic number parsing', () => {
 	const argv = ['hey', '--foo', '1234', 'hello'];
 	expect(arg({'--foo': Number}, {argv})).to.deep.equal({_: ['hey', 'hello'], '--foo': 1234});


### PR DESCRIPTION
Fixes #47 