### PR TITLE
fix(types): export flagSymbol

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,14 +1,14 @@
-declare const flagSymbol: unique symbol;
-
 declare function arg<T extends arg.Spec>(
 	spec: T,
 	options?: arg.Options
 ): arg.Result<T>;
 
 declare namespace arg {
-	export function flag<T>(fn: T): T & { [flagSymbol]: true };
+	export const flagSymbol: unique symbol;
 
-	export const COUNT: Handler<number> & { [flagSymbol]: true };
+	export function flag<T>(fn: T): T & { [arg.flagSymbol]: true };
+
+	export const COUNT: Handler<number> & { [arg.flagSymbol]: true };
 
 	export type Handler<T = any> = (
 		value: string,


### PR DESCRIPTION
This commit fixes #62. I've tested it locally in my project by running `npm link` in the `arg` repository with this fix applied, and then running `npm link arg` in my project. The TypeScript error that I was initially getting is resolved and `arg` functions properly.